### PR TITLE
Protect against deleted objects in TargetsMany and PerformsExport

### DIFF
--- a/app/models/concerns/actions/performs_export.rb
+++ b/app/models/concerns/actions/performs_export.rb
@@ -56,7 +56,7 @@ module Actions::PerformsExport
     if target_all?
       "Export of all #{subject.titleize}"
     elsif target_ids.one?
-      "Export of #{targeted.first.label_string}"
+      "Export of #{targeted.first&.label_string || 'deleted object'}"
     else
       "Export of #{target_ids.count} #{subject.titleize.pluralize(target_ids.count)}"
     end

--- a/app/models/concerns/actions/targets_many.rb
+++ b/app/models/concerns/actions/targets_many.rb
@@ -7,7 +7,7 @@ module Actions::TargetsMany
     if target_all?
       "#{super} on all #{valid_targets.arel_table.name.titleize}"
     elsif target_ids.one?
-      "#{super} on #{targeted.first.label_string}"
+      "#{super} on #{targeted.first&.label_string || 'deleted object'}"
     else
       "#{super} on #{target_ids.count} #{valid_targets.arel_table.name.titleize.pluralize(target_ids.count)}"
     end


### PR DESCRIPTION
If `target_ids` has one item and that item has been deleted, `label_string` blows up. This protects against that case.