### PR TITLE
Allow accept value to be set

### DIFF
--- a/app/views/shared/actions/imports/_fields.html.erb
+++ b/app/views/shared/actions/imports/_fields.html.erb
@@ -1,5 +1,6 @@
 <% form ||= current_fields_form %>
+<% accept ||= "" %>
 
-<%= render 'shared/fields/file_field', method: :file %>
+<%= render 'shared/fields/file_field', method: :file, accept: accept %>
 <%= render 'shared/fields/super_select', method: :copy_mapping_from_id, options: {include_blank: t("#{form.object.class.name.underscore.pluralize}.fields.copy_mapping_from_id.placeholder")},
   choices: form.object.valid_copy_mapping_froms.select(&:persisted?).map { |performs_import_action| [performs_import_action.label_string, performs_import_action.id] } %>


### PR DESCRIPTION
This allows you to pass in an `accept` value to the `fields` partial so you can specify the file types to be accepted by the file selector.

`<%= render 'shared/actions/imports/fields', accept: "text/csv" %>`

<img width="589" alt="Screen Shot 2022-12-01 at 16 36 50" src="https://user-images.githubusercontent.com/78157/205018233-a814f17e-7df5-4f76-b82f-0729751d7abf.png">

I'm not sure if there's a better way to do this. 🤔 