### PR TITLE
Use download method to get CSV contents

### DIFF
--- a/app/models/concerns/actions/performs_import.rb
+++ b/app/models/concerns/actions/performs_import.rb
@@ -44,7 +44,7 @@ module Actions::PerformsImport
     # Docs: https://apidock.com/rails/v6.1.3.1/ActiveStorage/Attached/Model/attachment_changes
     # Discussion: https://github.com/rails/rails/pull/37005
     string = if self.attachment_changes['file'].present?
-      self.attachment_changes['file'].attachable.read
+      self.attachment_changes['file'].attachment.download
     else
       file.download
     end


### PR DESCRIPTION
I was looking into #25 and noticed the `csv` method wasn't working. The original line we had here gave me a random string instead of the CSV's contents, so the `read` method was raising an error.

With that being said I think I'll leave #25 for a bit. I'm still running into errors like what's in #20 (although the errors could just be the result of how I'm setting things up).

I think I have a better idea of how imports are supposed to work though, so I definitely want to come back to it soon.
