### PR TITLE
Skip adding roles when scaffolding in admin namespace

### DIFF
--- a/lib/scaffolding/action_model_transformer.rb
+++ b/lib/scaffolding/action_model_transformer.rb
@@ -189,7 +189,7 @@ class Scaffolding::ActionModelTransformer < Scaffolding::Transformer
     add_button_to_index
     add_button_to_index_rows
     add_index_to_parent
-    add_has_many_to_parent_model unless admin_namespace?
+    add_has_many_to_parent_model
     update_action_models_abstract_class(targets_n)
     add_permit_joins_and_delegations
     add_ability_line_to_roles_yml unless admin_namespace?


### PR DESCRIPTION
Closes #27.

## Details
Pretty straightforward. I saw there was another `add_ability_line_to_roles_yml` method in `lib/scaffolding/action_model_performs_export_transformer.rb`, but it looks like we cover it because that class is inheriting `Scaffolding::ActionModelTransformer`.

## `replace_has_one`
I wanted to close #28 as well, but I don't see any implementation of this method:

https://github.com/bullet-train-pro/bullet_train-action_models/blob/e08a2b6521d4757a58c51960adcf4a1bdf40b8f4/lib/scaffolding/action_model_transformer.rb#L126-L132

I originally thought it was the `add_has_many_to_parent_model` line that I had to bypass (you can see I added it in the first commit, then deleted it).

Since this is scaffolded when we Super Scaffold the original model, maybe we should delete the line when the namespace is Admin.

I would be glad to work on #28 too, I'm just not sure where the `has_one :team, through: ...` is besides the method definition.