### PR TITLE
Avoid Action Record View Error

### DIFF
--- a/app/models/concerns/actions/performs_export.rb
+++ b/app/models/concerns/actions/performs_export.rb
@@ -55,8 +55,6 @@ module Actions::PerformsExport
   def label_string
     if target_all?
       "Export of all #{subject.titleize}"
-    elsif target_ids.one?
-      "Export of #{targeted.first.label_string}"
     else
       "Export of #{target_ids.count} #{subject.titleize.pluralize(target_ids.count)}"
     end

--- a/app/models/concerns/actions/targets_many.rb
+++ b/app/models/concerns/actions/targets_many.rb
@@ -6,8 +6,6 @@ module Actions::TargetsMany
   def label_string
     if target_all?
       "#{super} on all #{valid_targets.arel_table.name.titleize}"
-    elsif target_ids.one?
-      "#{super} on #{targeted.first.label_string}"
     else
       "#{super} on #{target_ids.count} #{valid_targets.arel_table.name.titleize.pluralize(target_ids.count)}"
     end


### PR DESCRIPTION
There is a method called `valid_targets` on any `ImportAction` record. It is conceivable that the value for that will change over time. Our company had an Action record with ONE target. That target record was submitted as a part of an action, but then a subsequent update to her underlying `target` record rendered her no longer a `valid_target`. 

When we tried to render that `ImportAction` record, the view errored out, because `targeted.first` was nil