### PR TITLE
display nothing to indicate that field will not be imported

### DIFF
--- a/app/views/shared/attributes/actions/_mapping.html.erb
+++ b/app/views/shared/attributes/actions/_mapping.html.erb
@@ -15,7 +15,7 @@
             <% object.send(attribute).each do |key, value| %>
               <tr>
                 <td><code><%= key %></code></td>
-                <td><strong><%= value.present? ? t("#{object.subject.name.underscore.pluralize}.fields.#{value}.heading") : "Don't Import" %></strong></td>
+                <td><strong><%= value.present? ? t("#{object.subject.name.underscore.pluralize}.fields.#{value}.heading") : "" %></strong></td>
               </tr>
             <% end %>
           </tbody>


### PR DESCRIPTION
Matt made the comment that there was "clutter" when viewing your field mappings for a particular Import CSV, I agreed.

He prefers this:
![Screen Shot 2023-01-26 at 3 15 43 PM](https://user-images.githubusercontent.com/16711232/214952860-06c93c59-4765-45ba-9012-24056ede65cd.png)

To that:
![Screen Shot 2023-01-26 at 3 15 57 PM](https://user-images.githubusercontent.com/16711232/214952836-98871bff-3e94-4771-b875-ca0038d47f3e.png)


