### PR TITLE
[Accounts] ACC-156 - Step 1 - Pass AR object to mark row processed

### DIFF
--- a/app/models/concerns/actions/performs_import.rb
+++ b/app/models/concerns/actions/performs_import.rb
@@ -93,7 +93,7 @@ module Actions::PerformsImport
     super
   end
 
-  def mark_row_processed(target)
+  def after_row_processed(target)
     increment :succeeded_count
   end
 
@@ -122,7 +122,7 @@ module Actions::PerformsImport
   def update_target_with_row(target, row)
     # Try updating the target with a mapped version of the row.
     if target.update(map_row(row).except(PRIMARY_KEY_FIELD.to_s))
-      mark_row_processed(target)
+      after_row_processed(target)
     else
       mark_row_failed(row, target.errors.full_messages.to_sentence + ".")
     end
@@ -131,7 +131,7 @@ module Actions::PerformsImport
   def create_target_from_row(subject, row)
     # Try creating the target with a mapped version of the row.
     if (target = subject.new(map_row(row).except(PRIMARY_KEY_FIELD.to_s))).save
-      mark_row_processed(target)
+      after_row_processed(target)
     else
       mark_row_failed(row, target.errors.full_messages.to_sentence + ".")
     end


### PR DESCRIPTION
This needs to be merged before we can merge https://github.com/clickfunnels2/admin/pull/15864. 

I have a PR where I want to do something after each row gets processed. Specifically, I want to create a `Contact::AppliedTag` record after each row is successfully uploaded.

I originally thought `after_each` was the go-to method. However,  this method runs after every record gets processed, **whether it is successful or not**.

So there are two changes here:

1. `mark_row_processed` was renamed to `after_row_processed`
2. We are passing an active record object to the method, so that we can use it to do more things, like creating an associated AR object. For instance, here is my override that I will include in a PR to create a Tag on row create:
```
  def after_row_processed(record)
    super

    record.applied_tags.create(tag: tag)
  end
```



