### PR TITLE
Bail out early if ProcessesAsync discovers it has been included in the wrong order

### DIFF
--- a/app/models/concerns/actions/base.rb
+++ b/app/models/concerns/actions/base.rb
@@ -5,6 +5,8 @@ module Actions::Base
     after_commit :dispatch, on: [:create]
     scope :active, -> { where.not(started_at: nil).where(completed_at: nil) }
     scope :completed, -> { where.not(completed_at: nil) }
+
+    @_actions_base_included = true
   end
 
   def label_string

--- a/app/models/concerns/actions/processes_async.rb
+++ b/app/models/concerns/actions/processes_async.rb
@@ -1,6 +1,13 @@
 module Actions::ProcessesAsync
   extend ActiveSupport::Concern
 
+  included do
+    unless @_actions_base_included
+      warn "ERROR: In #{self.name}: Actions::ProcessesAsync must be included _after_ Actions::Base, usually via Actions::TargetsOne or Actions::TargetsMany"
+      exit 254
+    end
+  end
+
   def dispatch
     self.sidekiq_jid = Actions::BackgroundActionWorker.perform_async(self.class.name, id)
     save

--- a/app/models/scaffolding/completely_concrete/tangible_things/performs_export_action.rb
+++ b/app/models/scaffolding/completely_concrete/tangible_things/performs_export_action.rb
@@ -5,9 +5,10 @@ class Scaffolding::CompletelyConcrete::TangibleThings::PerformsExportAction < Ap
   end
   # 🚅 stop any skipping we're doing now.
 
-  include Actions::ProcessesAsync
   include Actions::TracksCreator
   include Actions::PerformsExport # 🚅 skip when scaffolding.
+  include Actions::ProcessesAsync
+
   # 🚅 add concerns above.
 
   # 🚅 add attribute accessors above.

--- a/app/models/scaffolding/completely_concrete/tangible_things/performs_import_action.rb
+++ b/app/models/scaffolding/completely_concrete/tangible_things/performs_import_action.rb
@@ -1,6 +1,6 @@
 class Scaffolding::CompletelyConcrete::TangibleThings::PerformsImportAction < ApplicationRecord
-  include Actions::ProcessesAsync
   include Actions::PerformsImport # 🚅 skip when scaffolding.
+  include Actions::ProcessesAsync
   # 🚅 add concerns above.
 
   belongs_to :absolutely_abstract_creative_concept, class_name: "Scaffolding::AbsolutelyAbstract::CreativeConcept"


### PR DESCRIPTION
`ActionModel::ProcessesAsync` must be included _after_ `ActionModel::Base` and if it isn't bad things happen.

In this case:

```ruby
class SomeAction < ApplicationRecord
  include ActionModel::TargetsMany
  include ActionModel::ProcessesAsync
end
```

`TargetsMany` requires `Base` which [defines the `dispatch` method](https://github.com/bullet-train-pro/bullet_train-action_models/blob/main/app/models/concerns/actions/base.rb#L14-L16) to just call `perform`. `ProcessesAsync` [overrides the `dispatch` method](https://github.com/bullet-train-pro/bullet_train-action_models/blob/main/app/models/concerns/actions/processes_async.rb#L4-L7) to instead kick a Sidekiq job.

However, in the inverse case:

```ruby
class SomeAction < ApplicationRecord
  include ActionModel::ProcessesAsync
  include ActionModel::TargetsMany
end
```

`Base`'s dispatch will override `ProcessesAsync`'s `dispatch` and cause the job to run inline, which we can safely assume is never the author's intent.

This PR fatally errors when this situation is detected. We `exit` instead of `raise` because an exception thrown in `included`  is sometimes, but not always, caught in loading and I couldn't figure out why or how.
