### PR TITLE
Use new `option` partial for check boxes

### DIFF
--- a/app/views/shared/tables/_checkbox.html.erb
+++ b/app/views/shared/tables/_checkbox.html.erb
@@ -1,6 +1,6 @@
 <td class="bulk-actions-checkbox-cell">
   <label>
-    <%= render 'shared/fields/option', method: :bulk_actions_ids, single_check_box: true,
+    <%= render 'shared/fields/option', method: :bulk_actions_ids, single_check_box: true, append_class: '-mt-0.5',
       option_field_options: {
         value: object.id,
         checked: false,

--- a/app/views/shared/tables/_checkbox.html.erb
+++ b/app/views/shared/tables/_checkbox.html.erb
@@ -1,6 +1,12 @@
 <td class="bulk-actions-checkbox-cell">
   <label>
-    <%= check_box_tag :bulk_actions_ids, object.id, false, data: { 'bulk-actions-target': 'checkbox', 'action': 'bulk-actions#updateSelectedIds' }, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded -mt-0.5" %>
+    <%= render 'shared/fields/option', method: :bulk_actions_ids, single_check_box: true,
+      option_field_options: {
+        value: object.id,
+        checked: false,
+        data: { 'bulk-actions-target': 'checkbox', 'action': 'bulk-actions#updateSelectedIds' }
+      }
+    %>
     <span class="hidden"><%= object.label_string %></span>
   </label>
 </td>

--- a/app/views/shared/tables/_select_all.html.erb
+++ b/app/views/shared/tables/_select_all.html.erb
@@ -1,6 +1,6 @@
 <th class="bulk-actions-checkbox-cell">
   <label style="line-height: 0;">
-    <%= render 'shared/fields/option', method: :bulk_actions_select_all, single_check_box: true,
+    <%= render 'shared/fields/option', method: :bulk_actions_select_all, single_check_box: true, append_class: '-mt-1',
       option_field_options: {
         value: 'select_all',
         checked: false,

--- a/app/views/shared/tables/_select_all.html.erb
+++ b/app/views/shared/tables/_select_all.html.erb
@@ -1,6 +1,12 @@
 <th class="bulk-actions-checkbox-cell">
   <label style="line-height: 0;">
-    <%= check_box_tag :bulk_actions_select_all, 'select-all', false, data: { 'bulk-actions-target': 'selectAllCheckbox', 'action': 'bulk-actions#selectAllOrNone' }, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded -mt-1" %>
+    <%= render 'shared/fields/option', method: :bulk_actions_select_all, single_check_box: true,
+      option_field_options: {
+        value: :bulk_actions_select_all,
+        checked: false,
+        data: { 'bulk-actions-target': 'selectAllCheckbox', 'action': 'bulk-actions#selectAllOrNone' }
+      }
+    %>
     <span class="hidden"
       data-bulk-actions-target="selectAllLabel"
       data-controller="text-toggle"

--- a/app/views/shared/tables/_select_all.html.erb
+++ b/app/views/shared/tables/_select_all.html.erb
@@ -2,7 +2,7 @@
   <label style="line-height: 0;">
     <%= render 'shared/fields/option', method: :bulk_actions_select_all, single_check_box: true,
       option_field_options: {
-        value: :bulk_actions_select_all,
+        value: 'select_all',
         checked: false,
         data: { 'bulk-actions-target': 'selectAllCheckbox', 'action': 'bulk-actions#selectAllOrNone' }
       }


### PR DESCRIPTION
Closes #47.

Depends on the following PR since I implemented the option partial:
- https://github.com/bullet-train-co/bullet_train-core/pull/148

The Action Model system tests are passing locally for me, so we should be good to go.

# TODO
I technically haven't added the following styles that I deleted at the end of the class (after "rounded") in the two partials in this PR:
1. `-mt-0.5`
2. `-mt-1`
