### PR TITLE
Set allow_clear to true for mapping select

### DIFF
--- a/app/views/shared/actions/imports/_fields.html.erb
+++ b/app/views/shared/actions/imports/_fields.html.erb
@@ -2,5 +2,8 @@
 <% accept ||= "" %>
 
 <%= render 'shared/fields/file_field', method: :file, accept: accept %>
-<%= render 'shared/fields/super_select', method: :copy_mapping_from_id, options: {include_blank: t("#{form.object.class.name.underscore.pluralize}.fields.copy_mapping_from_id.placeholder")},
-  choices: form.object.valid_copy_mapping_froms.select(&:persisted?).map { |performs_import_action| [import_label_with_time(performs_import_action), performs_import_action.id] } %>
+<%= render 'shared/fields/super_select',
+    method: :copy_mapping_from_id,
+    options: {include_blank: t("#{form.object.class.name.underscore.pluralize}.fields.copy_mapping_from_id.placeholder")},
+    other_options: {allow_clear: true},
+    choices: form.object.valid_copy_mapping_froms.select(&:persisted?).map { |performs_import_action| [import_label_with_time(performs_import_action), performs_import_action.id] } %>


### PR DESCRIPTION
This allows the user to clear the field if they accidentally select an option

![clear-mapping](https://user-images.githubusercontent.com/78157/223055418-ad6b3339-0438-4821-931d-23aebbd3d720.gif)
