### PR TITLE
Ensure `has_one` association is removed properly

### DIFF
--- a/lib/scaffolding/action_model_transformer.rb
+++ b/lib/scaffolding/action_model_transformer.rb
@@ -139,8 +139,7 @@ class Scaffolding::ActionModelTransformer < Scaffolding::Transformer
   def remove_team_has_one_team
     scaffold_replace_line_in_file(
       "./app/models/scaffolding/completely_concrete/tangible_things/#{targets_n}_action.rb",
-      # TODO Why can't this be ""?
-      "# TODO Remove this TODO, but not the comment after it. This TODO is a result of a bug we need to fix in Super Scaffolding.",
+      "",
       "has_one :team, through: :team",
     )
   end


### PR DESCRIPTION
Joint PR:
- https://github.com/bullet-train-co/bullet_train-core/pull/162

All the details for why this fix works is in the joint PR.

## `Scaffolding::FileTransformer#replace_line_in_file`
I wanted to use this method instead because it handles more general replacement, but we need to transform the file name. We could technically transform the file name first and then pass it to `Scaffolding::FileTransformer#replace_line_in_file` if that makes more sense, but I've at least written things this way to get things working for the time being.