### PR TITLE
Fixes for TargetsMany and PerformsExport

### DIFF
--- a/app/models/concerns/actions/performs_export.rb
+++ b/app/models/concerns/actions/performs_export.rb
@@ -28,6 +28,12 @@ module Actions::PerformsExport
     @csv << fields
   end
 
+  def before_page
+    # We need to call this in before_page because we need @tempfile and @csv populated
+    # even in the case where super.remaining_targets is empty
+    before_each
+  end
+
   def before_each
     unless @tempfile
       @tempfile = Tempfile.new

--- a/app/models/concerns/actions/targets_many.rb
+++ b/app/models/concerns/actions/targets_many.rb
@@ -33,7 +33,7 @@ module Actions::TargetsMany
   end
 
   def remaining_targets
-    targeted.where("id > ?", last_completed_id).where.not(id: failed_ids)
+    targeted.where(":id is null or id > :id", id: last_completed_id).where.not(id: failed_ids)
   end
 
   def health_check_frequency


### PR DESCRIPTION
* Fix `remaining_targets` query. When `last_completed_id` is nil the query returns nothing instead of everything.
* Always call `before_each` in `PerformsExport#before_page` to set up `@tempfile` and `@csv`