### PR TITLE
Revert download method change.

### DIFF
--- a/app/models/concerns/actions/performs_import.rb
+++ b/app/models/concerns/actions/performs_import.rb
@@ -44,7 +44,7 @@ module Actions::PerformsImport
     # Docs: https://apidock.com/rails/v6.1.3.1/ActiveStorage/Attached/Model/attachment_changes
     # Discussion: https://github.com/rails/rails/pull/37005
     string = if attachment_changes["file"].present?
-      attachment_changes["file"].attachment.download
+      attachment_changes["file"].attachable.read
     else
       file.download
     end


### PR DESCRIPTION
@scottharvey is reporting that this change broke his downstream CSV import workflow. Now that we have more robust testing around this, I'm pushing this up just to see whether it passes CI when we revert it.