### PR TITLE
Improvement - Allow user to specify a target_model_name for label_string

### DIFF
--- a/app/models/concerns/actions/targets_many.rb
+++ b/app/models/concerns/actions/targets_many.rb
@@ -5,10 +5,15 @@ module Actions::TargetsMany
   # TODO Improve the localization of this.
   def label_string
     if target_all?
-      "#{super} on all #{valid_targets.arel_table.name.titleize}"
+      "#{super} on all #{target_model_name}"
     else
-      "#{super} on #{target_ids.count} #{valid_targets.arel_table.name.titleize.pluralize(target_ids.count)}"
+      "#{super} on #{target_ids.count} #{target_model_name.pluralize(target_ids.count)}"
     end
+  end
+
+  # Override this method in your model to change this value. For use if `valid_targets` does not return an AR scope
+  def target_model_name
+    valid_targets.arel_table.name.titleize
   end
 
   def valid_targets


### PR DESCRIPTION
Currently, if the implementing class returning anything other than an AR scope (or otherwise making database queries) - any time we call `label_string` for an action model it will actually fully run these methods just to get the name of the target model class. This allows the user to override this behavior in these rare situations where an AR scope is not directly returned.