### PR TITLE
allow characters like é

### DIFF
--- a/app/models/concerns/actions/performs_import.rb
+++ b/app/models/concerns/actions/performs_import.rb
@@ -22,7 +22,7 @@ module Actions::PerformsImport
   end
 
   def csv
-    @csv ||= CSV.parse(parsed_csv, headers: true, encoding: 'utf-8')
+    @csv ||= CSV.parse(parsed_csv, headers: true, encoding: "utf-8")
   end
 
   def rejected_file_path


### PR DESCRIPTION
https://linear.app/clickfunnels/issue/APP-290/contact-imports-make-work-for-weird-non-utf-8-characters