### PR TITLE
Prevent health check loop when action fails

### DIFF
--- a/app/models/concerns/actions/targets_many.rb
+++ b/app/models/concerns/actions/targets_many.rb
@@ -70,8 +70,9 @@ module Actions::TargetsMany
           perform_on_target(object)
           update_column(:last_completed_id, object.id)
         end
-      rescue => _
+      rescue => e
         failed_ids << object.id
+        self.error_messages = e
         save
       end
 

--- a/app/models/concerns/actions/targets_many.rb
+++ b/app/models/concerns/actions/targets_many.rb
@@ -72,7 +72,7 @@ module Actions::TargetsMany
         end
       rescue => e
         failed_ids << object.id
-        self.error_messages = e
+        self.error_message = e
         save
       end
 

--- a/app/models/concerns/actions/targets_many.rb
+++ b/app/models/concerns/actions/targets_many.rb
@@ -72,7 +72,9 @@ module Actions::TargetsMany
         end
       rescue => e
         failed_ids << object.id
-        self.error_message = e if self.respond_to?(:error_message)
+        if e.class < StandardError && self.respond_to?(:error_message)
+          self.error_message = e
+        end
         save
       end
 

--- a/app/models/concerns/actions/targets_many.rb
+++ b/app/models/concerns/actions/targets_many.rb
@@ -72,7 +72,7 @@ module Actions::TargetsMany
         end
       rescue => e
         failed_ids << object.id
-        self.error_message = e
+        self.error_message = e if self.respond_to?(:error_message)
         save
       end
 

--- a/app/workers/actions/background_action_health_check_worker.rb
+++ b/app/workers/actions/background_action_health_check_worker.rb
@@ -5,11 +5,13 @@ class Actions::BackgroundActionHealthCheckWorker
     class_name, id = args
     action = class_name.constantize.find_by(id: id)
 
+    return unless action
+
     # Skip everything if the job is actually completed. We're done here.
-    return if action && action.completed_at.present?
+    return if action.completed_at.present?
 
     # If there is an error message then don't try to run the check again
-    return if action && action.error_message.present?
+    return if action.error_message.present?
 
     # If the action hasn't completed a unit of work within a specified period of time.
     if action.updated_at < action.health_check_timeout.ago

--- a/app/workers/actions/background_action_worker.rb
+++ b/app/workers/actions/background_action_worker.rb
@@ -4,5 +4,7 @@ class Actions::BackgroundActionWorker
   def perform(*args)
     class_name, id = args
     class_name.constantize.find(id).perform
+  rescue StandardError => e
+    class_name.constantize.find(id).update error_message: e
   end
 end

--- a/app/workers/actions/background_action_worker.rb
+++ b/app/workers/actions/background_action_worker.rb
@@ -4,7 +4,5 @@ class Actions::BackgroundActionWorker
   def perform(*args)
     class_name, id = args
     class_name.constantize.find(id).perform
-  rescue StandardError => e
-    class_name.constantize.find(id).update error_message: e
   end
 end

--- a/db/migrate/20220117161946_create_scaffolding_completely_concrete_tangible_things_targets_many_actions.rb
+++ b/db/migrate/20220117161946_create_scaffolding_completely_concrete_tangible_things_targets_many_actions.rb
@@ -5,6 +5,7 @@ class CreateScaffoldingCompletelyConcreteTangibleThingsTargetsManyActions < Acti
       t.boolean :target_all, default: false
       t.jsonb :target_ids, default: []
       t.string :emoji
+      t.string :error_message
       t.bigint :target_count
       t.bigint :performed_count, default: 0
       t.references :created_by, null: true, foreign_key: {to_table: "memberships"}, index: {name: "index_append_emoji_actions_on_created_by_id"}

--- a/db/migrate/20220118171402_create_scaffolding_completely_concrete_tangible_things_targets_one_actions.rb
+++ b/db/migrate/20220118171402_create_scaffolding_completely_concrete_tangible_things_targets_one_actions.rb
@@ -3,6 +3,7 @@ class CreateScaffoldingCompletelyConcreteTangibleThingsTargetsOneActions < Activ
     create_table :sc_completely_concrete_tangible_things_targets_one_actions do |t|
       t.references :tangible_thing, null: false, foreign_key: {to_table: "scaffolding_completely_concrete_tangible_things"}, index: {name: "index_tangible_things_targets_one_actions_on_tangible_thing_id"}
       t.string :emoji
+      t.string :error_message
       t.integer :target_count
       t.integer :performed_count, default: 0
       t.references :created_by, null: true, foreign_key: {to_table: "memberships"}, index: {name: "index_targets_ones_on_created_by_id"}

--- a/db/migrate/20220121160731_create_scaffolding_completely_concrete_tangible_things_targets_one_parent_actions.rb
+++ b/db/migrate/20220121160731_create_scaffolding_completely_concrete_tangible_things_targets_one_parent_actions.rb
@@ -7,6 +7,7 @@ class CreateScaffoldingCompletelyConcreteTangibleThingsTargetsOneParentActions <
       t.integer :target_count
       t.integer :performed_count, default: 0
       t.datetime :scheduled_for
+      t.string :error_message
       t.string :sidekiq_jid
       t.references :created_by, null: false, foreign_key: {to_table: "memberships"}, index: {name: "index_targets_one_parents_on_created_by_id"}
       t.references :approved_by, null: true, foreign_key: {to_table: "memberships"}, index: {name: "index_targets_one_parents_on_approved_by_id"}

--- a/db/migrate/20220715105001_create_scaffolding_completely_concrete_tangible_things_targets_many_actions copy.rb
+++ b/db/migrate/20220715105001_create_scaffolding_completely_concrete_tangible_things_targets_many_actions copy.rb
@@ -6,6 +6,7 @@ class CreateScaffoldingCompletelyConcreteTangibleThingsPerformsExportActions < A
       t.jsonb :target_ids, default: []
       t.bigint :target_count
       t.bigint :performed_count, default: 0
+      t.string :error_message
       t.references :created_by, null: true, foreign_key: {to_table: "memberships"}, index: {name: "index_append_emoji_actions_on_created_by_id"}
       t.references :approved_by, null: true, foreign_key: {to_table: "memberships"}, index: {name: "index_append_emoji_actions_on_approved_by_id"}
       t.datetime :scheduled_for

--- a/db/migrate/20220721223017_create_scaffolding_completely_concrete_tangible_things_performs_import_actions.rb
+++ b/db/migrate/20220721223017_create_scaffolding_completely_concrete_tangible_things_performs_import_actions.rb
@@ -8,6 +8,7 @@ class CreateScaffoldingCompletelyConcreteTangibleThingsPerformsImportActions < A
       t.integer :performed_count, default: 0
       t.datetime :scheduled_for
       t.string :sidekiq_jid
+      t.string :error_message
       t.jsonb :mapping, default: []
       t.references :copy_mapping_from, null: true, foreign_key: {to_table: "scaffolding_completely_concrete_tangible_things_performs_import_actions"}, index: {name: "index_performs_imports_on_copy_mapping_from_id"}
       t.integer :succeeded_count, default: 0


### PR DESCRIPTION
I'm just opening this PR for discussion at this stage.

This PR aims to fix an issue which is caused by the `Actions::BackgroundActionHealthCheckWorker` when it continually keeps running an action which is never going to pass due to an exception being raise.

The idea here is to record when an exception happens and then don't re-run an action which has raised an exception in a previous run