### PR TITLE
Add option for disabling health check worker.

### DIFF
--- a/app/models/concerns/actions/processes_async.rb
+++ b/app/models/concerns/actions/processes_async.rb
@@ -10,6 +10,7 @@ module Actions::ProcessesAsync
 
   def schedule_health_check
     return false if Rails.env.test?
+    return false unless BulletTrain::ActionModels.health_check_worker
     Actions::BackgroundActionHealthCheckWorker.perform_at(health_check_frequency.from_now, self.class.name, id)
   end
 

--- a/lib/bullet_train/action_models.rb
+++ b/lib/bullet_train/action_models.rb
@@ -12,6 +12,6 @@ require "bullet_train/action_models/scaffolders/targets_one_parent_scaffolder"
 
 module BulletTrain
   module ActionModels
-    # Your code goes here...
+    mattr_accessor :health_check_worker, default: true
   end
 end


### PR DESCRIPTION
To disable the health check worker (for Sidekiq Pro users) developers can create a `config/initializers/action_models.rb` that defines:

```
BulletTrain::ActionModels.health_check_worker = false
```