### PR TITLE
remove breaking method

### DIFF
--- a/app/models/concerns/actions/performs_import.rb
+++ b/app/models/concerns/actions/performs_import.rb
@@ -245,9 +245,7 @@ module Actions::PerformsImport
         attachment_changes["file"].attachable
       end
 
-      parsed = Roo::Spreadsheet.open(attachment, {extension: File.extname(file.filename.to_s), csv_options: {liberal_parsing: true, encoding: "bom|utf-8"}}).to_csv
-
-      parsed.delete("\"") # The Roo::Spreadsheet.to_csv method above puts everything in double quotes, which we want to remove
+      Roo::Spreadsheet.open(attachment, {extension: File.extname(file.filename.to_s), csv_options: {liberal_parsing: true, encoding: "bom|utf-8"}}).to_csv
     end
   end
 end


### PR DESCRIPTION
I am not sure why I forced the method to delete double quotes.... It is causing tag imports to be affected, since we NEED this field to be double quoted, otherwise we cannot import multiple tags per row