### PR TITLE
Trying to be able to run action model tests in the starter repo

### DIFF
--- a/lib/bullet_train/action_models/scaffolders/performs_export_scaffolder.rb
+++ b/lib/bullet_train/action_models/scaffolders/performs_export_scaffolder.rb
@@ -4,6 +4,18 @@ module BulletTrain
   module ActionModels
     module Scaffolders
       class PerformsExportScaffolder < SuperScaffolding::Scaffolder
+        # TODO these methods were removed from the global scope in super scaffolding and moved to `Scaffolding::Transformer`,
+        # but this gem hasn't been updated yet.
+
+        def legacy_replace_in_file(file, before, after)
+          puts "Replacing in '#{file}'."
+          target_file_content = File.open(file).read
+          target_file_content.gsub!(before, after)
+          File.open(file, "w+") do |f|
+            f.write(target_file_content)
+          end
+        end
+
         def run
           unless argv.count >= 3
             puts ""
@@ -29,7 +41,7 @@ module BulletTrain
 
           transformer = Scaffolding::ActionModelPerformsExportTransformer.new(action_model, target_model, parent_models)
 
-          `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::PerformsExportAction")} #{transformer.transform_string("absolutely_abstract_creative_concept")}:references target_all:boolean target_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} failed_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} last_completed_id:integer started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references approved_by:references fields:#{Scaffolding.mysql? ? "json" : "jsonb"}`
+          `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::PerformsExportAction")} #{transformer.transform_string("absolutely_abstract_creative_concept")}:references target_all:boolean target_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} failed_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} last_completed_id:integer started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references{polymorphic} approved_by:references{polymorphic} fields:#{Scaffolding.mysql? ? "json" : "jsonb"}`
 
           transformer.scaffold_action_model
           transformer.fix_json_column_default("target_ids")

--- a/lib/bullet_train/action_models/scaffolders/performs_import_scaffolder.rb
+++ b/lib/bullet_train/action_models/scaffolders/performs_import_scaffolder.rb
@@ -4,6 +4,18 @@ module BulletTrain
   module ActionModels
     module Scaffolders
       class PerformsImportScaffolder < SuperScaffolding::Scaffolder
+        # TODO these methods were removed from the global scope in super scaffolding and moved to `Scaffolding::Transformer`,
+        # but this gem hasn't been updated yet.
+
+        def legacy_replace_in_file(file, before, after)
+          puts "Replacing in '#{file}'."
+          target_file_content = File.open(file).read
+          target_file_content.gsub!(before, after)
+          File.open(file, "w+") do |f|
+            f.write(target_file_content)
+          end
+        end
+
         def run
           unless argv.count >= 3
             puts ""
@@ -29,7 +41,7 @@ module BulletTrain
 
           transformer = Scaffolding::ActionModelPerformsImportTransformer.new(action_model, target_model, parent_models)
 
-          `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::PerformsImportAction")} #{transformer.transform_string("absolutely_abstract_creative_concept")}:references target_all:boolean target_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references approved_by:references mapping:#{Scaffolding.mysql? ? "json" : "jsonb"} copy_mapping_from:references succeeded_count:integer failed_count:integer last_processed_row:integer`
+          `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::PerformsImportAction")} #{transformer.transform_string("absolutely_abstract_creative_concept")}:references target_all:boolean target_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references{polymorphic} approved_by:references{polymorphic} mapping:#{Scaffolding.mysql? ? "json" : "jsonb"} copy_mapping_from:references succeeded_count:integer failed_count:integer last_processed_row:integer`
 
           copy_mapping_from_index_name = transformer.transform_string("index_scaffolding_completely_concrete_tangible_things_#{action_model.pluralize.underscore.downcase}_on_copy_mapping_from_id")
           copy_mapping_from_index_name = "index_#{action_model.pluralize.underscore.downcase}_on_copy_mapping_from_id" if copy_mapping_from_index_name.length > 63

--- a/lib/bullet_train/action_models/scaffolders/targets_many_scaffolder.rb
+++ b/lib/bullet_train/action_models/scaffolders/targets_many_scaffolder.rb
@@ -30,7 +30,7 @@ module BulletTrain
 
           transformer = Scaffolding::ActionModelTargetsManyTransformer.new(action_model, target_model, parent_models)
 
-          `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::TargetsManyAction")} #{transformer.transform_string("absolutely_abstract_creative_concept")}:references target_all:boolean target_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} failed_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} last_completed_id:integer started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references approved_by:references`
+          `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::TargetsManyAction")} #{transformer.transform_string("absolutely_abstract_creative_concept")}:references target_all:boolean target_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} failed_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} last_completed_id:integer started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references{polymorphic} approved_by:references{polymorphic}`
 
           transformer.scaffold_action_model
           transformer.fix_json_column_default("target_ids")

--- a/lib/bullet_train/action_models/scaffolders/targets_one_parent_scaffolder.rb
+++ b/lib/bullet_train/action_models/scaffolders/targets_one_parent_scaffolder.rb
@@ -30,7 +30,7 @@ module BulletTrain
 
           transformer = Scaffolding::ActionModelTargetsOneParentTransformer.new(action_model, target_model, parent_models)
 
-          puts `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::TargetsOneParentAction")} #{transformer.transform_string("absolutely_abstract_creative_concept")}:references started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references approved_by:references`
+          puts `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::TargetsOneParentAction")} #{transformer.transform_string("absolutely_abstract_creative_concept")}:references started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references{polymorphic} approved_by:references{polymorphic}`
 
           transformer.scaffold_action_model
 

--- a/lib/bullet_train/action_models/scaffolders/targets_one_scaffolder.rb
+++ b/lib/bullet_train/action_models/scaffolders/targets_one_scaffolder.rb
@@ -3,7 +3,19 @@ require "scaffolding/action_model_targets_one_transformer"
 module BulletTrain
   module ActionModels
     module Scaffolders
-      class TargetsOneScaffolder < SuperScaffolding::Scaffolder
+      # TODO these methods were removed from the global scope in super scaffolding and moved to `Scaffolding::Transformer`,
+      # but this gem hasn't been updated yet.
+
+      def legacy_replace_in_file(file, before, after)
+        puts "Replacing in '#{file}'."
+        target_file_content = File.open(file).read
+        target_file_content.gsub!(before, after)
+        File.open(file, "w+") do |f|
+          f.write(target_file_content)
+        end
+      end
+
+     class TargetsOneScaffolder < SuperScaffolding::Scaffolder
         def run
           unless argv.count >= 3
             puts ""
@@ -30,7 +42,7 @@ module BulletTrain
 
           transformer = Scaffolding::ActionModelTargetsOneTransformer.new(action_model, target_model, parent_models)
 
-          `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::TargetsOneAction")} #{transformer.transform_string("tangible_thing")}:references started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references approved_by:references`
+          `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::TargetsOneAction")} #{transformer.transform_string("tangible_thing")}:references started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references{polymorphic} approved_by:references{polymorphic}`
 
           transformer.scaffold_action_model
 

--- a/lib/scaffolding/action_model_targets_one_transformer.rb
+++ b/lib/scaffolding/action_model_targets_one_transformer.rb
@@ -1,6 +1,19 @@
 require "scaffolding/action_model_transformer"
 
 class Scaffolding::ActionModelTargetsOneTransformer < Scaffolding::ActionModelTransformer
+  # TODO these methods were removed from the global scope in super scaffolding and moved to `Scaffolding::Transformer`,
+  # but this gem hasn't been updated yet.
+
+  def legacy_replace_in_file(file, before, after)
+    puts "Replacing in '#{file}'."
+    target_file_content = File.open(file).read
+    target_file_content.gsub!(before, after)
+    File.open(file, "w+") do |f|
+      f.write(target_file_content)
+    end
+  end
+
+
   def targets_n
     "targets_one"
   end

--- a/lib/scaffolding/action_model_transformer.rb
+++ b/lib/scaffolding/action_model_transformer.rb
@@ -6,6 +6,17 @@ class Scaffolding::ActionModelTransformer < Scaffolding::Transformer
   RUBY_NEW_BULK_ACTION_MODEL_BUTTONS_PROCESSING_HOOK = "<%# 🚅 super scaffolding will insert new bulk action model buttons above this line. %>"
   RUBY_NEW_ACTION_MODEL_INDEX_VIEWS_PROCESSING_HOOK = "<%# 🚅 super scaffolding will insert new action model index views above this line. %>"
 
+  # TODO this method was removed from the global scope in super scaffolding and moved to `Scaffolding::Transformer`,
+  # but this gem hasn't been updated yet.
+  def legacy_replace_in_file(file, before, after)
+    puts "Replacing in '#{file}'."
+    target_file_content = File.open(file).read
+    target_file_content.gsub!(before, after)
+    File.open(file, "w+") do |f|
+      f.write(target_file_content)
+    end
+  end
+
   def initialize(action, child, parents, cli_options = {})
     super(child, parents, cli_options)
     self.action = action


### PR DESCRIPTION
I was trying to run the action model tests in the starter repo and was seeing two different errors that were preventing the setup script from even running.

1. Complaints about "`created_bys` is not a table" & "`approved_bys` is not a table"

   This seems to be related to how we're generating models on the command line.

2. Complaints about a missing method called `legacy_replace_in_file`