### PR TITLE
Add missing locale for targets one action

### DIFF
--- a/config/locales/en/scaffolding/completely_concrete/tangible_things/targets_one_actions.en.yml
+++ b/config/locales/en/scaffolding/completely_concrete/tangible_things/targets_one_actions.en.yml
@@ -67,6 +67,8 @@ en:
         _: &completed_at Completed At
         label: *completed_at
         heading: *completed_at
+      performed_count_over_target_count:
+        heading: Progress
       # 🚅 super scaffolding will insert new fields above this line.
       created_at:
         _: &created_at Added


### PR DESCRIPTION
We have the following locale in all of the actions except for `TargetsOne` which was causing a translation missing error:

https://github.com/bullet-train-pro/bullet_train-action_models/blob/1ac25fc1f2e4620573f50808541811b2af96ae00/config/locales/en/scaffolding/completely_concrete/tangible_things/performs_export_actions.en.yml#L77-L78

https://github.com/bullet-train-pro/bullet_train-action_models/blob/1ac25fc1f2e4620573f50808541811b2af96ae00/config/locales/en/scaffolding/completely_concrete/tangible_things/performs_import_actions.en.yml#L39-L40

https://github.com/bullet-train-pro/bullet_train-action_models/blob/1ac25fc1f2e4620573f50808541811b2af96ae00/config/locales/en/scaffolding/completely_concrete/tangible_things/targets_many_actions.en.yml#L77-L78

https://github.com/bullet-train-pro/bullet_train-action_models/blob/1ac25fc1f2e4620573f50808541811b2af96ae00/config/locales/en/scaffolding/completely_concrete/tangible_things/targets_one_parent_actions.en.yml#L77-L78
