### PR TITLE
Fixes related to `Actions::RequiresApproval`

### DIFF
--- a/app/controllers/api/v1/scaffolding/completely_concrete/tangible_things/targets_many_actions_controller.rb
+++ b/app/controllers/api/v1/scaffolding/completely_concrete/tangible_things/targets_many_actions_controller.rb
@@ -41,7 +41,8 @@ class Api::V1::Scaffolding::CompletelyConcrete::TangibleThings::TargetsManyActio
         *permitted_fields,
         :target_all,
         :scheduled_for,
-        :created_by_id,
+        :created_by,
+        :approved_by,
         # 🚅 super scaffolding will insert new fields above this line.
         *permitted_arrays,
         target_ids: [],

--- a/app/controllers/api/v1/scaffolding/completely_concrete/tangible_things/targets_one_actions_controller.rb
+++ b/app/controllers/api/v1/scaffolding/completely_concrete/tangible_things/targets_one_actions_controller.rb
@@ -42,7 +42,7 @@ class Api::V1::Scaffolding::CompletelyConcrete::TangibleThings::TargetsOneAction
         *permitted_fields,
         :target_count,
         :performed_count,
-        :created_by_id,
+        :created_by,
         :approved_by,
         :scheduled_for,
         :started_at,

--- a/app/controllers/api/v1/scaffolding/completely_concrete/tangible_things/targets_one_parent_actions_controller.rb
+++ b/app/controllers/api/v1/scaffolding/completely_concrete/tangible_things/targets_one_parent_actions_controller.rb
@@ -42,7 +42,7 @@ class Api::V1::Scaffolding::CompletelyConcrete::TangibleThings::TargetsOneParent
         *permitted_fields,
         :target_count,
         :performed_count,
-        :created_by_id,
+        :created_by,
         :approved_by,
         :scheduled_for,
         :started_at,

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/targets_many_actions/show.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/targets_many_actions/show.html.erb
@@ -20,7 +20,7 @@
             <%= render 'shared/attributes/text', attribute: :target_count %>
             <%= render 'shared/attributes/text', attribute: :performed_count %>
             <%= render 'shared/attributes/belongs_to', attribute: :created_by %>
-            <%= render 'shared/attributes/belongs_to', attribute: :approved_by %>
+            <%= render 'shared/attributes/belongs_to', attribute: :approved_by if Scaffolding::CompletelyConcrete::TangibleThings::TargetsManyAction.include?(Actions::RequiresApproval) %>
             <%= render 'shared/attributes/date_and_time', attribute: :scheduled_for %>
             <%= render 'shared/attributes/date_and_time', attribute: :started_at %>
             <%= render 'shared/attributes/date_and_time', attribute: :completed_at %>

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/targets_one_actions/show.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/targets_one_actions/show.html.erb
@@ -18,7 +18,7 @@
             <%= render 'shared/attributes/text', attribute: :target_count %>
             <%= render 'shared/attributes/text', attribute: :performed_count %>
             <%= render 'shared/attributes/belongs_to', attribute: :created_by %>
-            <%= render 'shared/attributes/belongs_to', attribute: :approved_by %>
+            <%= render 'shared/attributes/belongs_to', attribute: :approved_by if Scaffolding::CompletelyConcrete::TangibleThings::TargetsOneAction.include?(Actions::RequiresApproval) %>
             <%= render 'shared/attributes/date_and_time', attribute: :scheduled_for %>
             <%= render 'shared/attributes/date_and_time', attribute: :started_at %>
             <%= render 'shared/attributes/date_and_time', attribute: :completed_at %>

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/targets_one_parent_actions/show.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/targets_one_parent_actions/show.html.erb
@@ -14,7 +14,7 @@
             <%= render 'shared/attributes/text', attribute: :target_count %>
             <%= render 'shared/attributes/text', attribute: :performed_count %>
             <%= render 'shared/attributes/belongs_to', attribute: :created_by %>
-            <%= render 'shared/attributes/belongs_to', attribute: :approved_by %>
+            <%= render 'shared/attributes/belongs_to', attribute: :approved_by if Scaffolding::CompletelyConcrete::TangibleThings::TargetsOneParentAction.include?(Actions::RequiresApproval) %>
             <%= render 'shared/attributes/date_and_time', attribute: :scheduled_for %>
             <%= render 'shared/attributes/date_and_time', attribute: :started_at %>
             <%= render 'shared/attributes/date_and_time', attribute: :completed_at %>


### PR DESCRIPTION
Opening in favor if #15.

## Description

The `Actions::RequiresApproval` module is optional for the following actions
1. targets-many
2. targets-one
3. targets-one-parent

Although it is an optional module, we were trying to show the `approved_by` attribute in the show views for these actions. We were getting an undefined method `approved_by` error because the reflection wasn't being declared, and it's only declared when we include the module.

## When `Actions::RequiresApproval` isn't included
```
irb(main):001> Projects::ArchiveAction.first
  Projects::ArchiveAction Load (0.5ms)  SELECT "projects_archive_actions".* FROM "projects_archive_actions" ORDER BY "projects_archive_actions"."id" ASC LIMIT $1  [["LIMIT", 1]]
=> 
#<Projects::ArchiveAction:0x00007ff27e4b86b0
 id: 1,
 team_id: 1,
 target_all: true,
 target_ids: ["1", "2"],
 failed_ids: [],
 last_completed_id: 2,
 started_at: Fri, 29 Sep 2023 05:13:38.089497000 UTC +00:00,
 completed_at: Fri, 29 Sep 2023 05:13:38.138579000 UTC +00:00,
 target_count: 2,
 performed_count: 2,
 scheduled_for: nil,
 sidekiq_jid: "a93846593245595f801362af",
 created_by_id: 1,
 approved_by_id: nil,
 created_at: Fri, 29 Sep 2023 05:13:37.902600000 UTC +00:00,
 updated_at: Fri, 29 Sep 2023 05:13:38.142854000 UTC +00:00>
irb(main):002> Projects::ArchiveAction.first.approved_by
  Projects::ArchiveAction Load (0.4ms)  SELECT "projects_archive_actions".* FROM "projects_archive_actions" ORDER BY "projects_archive_actions"."id" ASC LIMIT $1  [["LIMIT", 1]]
/home/gazayas/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/activemodel-7.0.8/lib/active_model/attribute_methods.rb:450:in `method_missing': undefined method `approved_by' for #<Projects::ArchiveAction id: 1, team_id: 1, target_all: true, target_ids: ["1", "2"], failed_ids: [], last_completed_id: 2, started_at: "2023-09-29 05:13:38.089497000 +0000", completed_at: "2023-09-29 05:13:38.138579000 +0000", target_count: 2, performed_count: 2, scheduled_for: nil, sidekiq_jid: "a93846593245595f801362af", created_by_id: 1, approved_by_id: nil, created_at: "2023-09-29 05:13:37.902600000 +0000", updated_at: "2023-09-29 05:13:38.142854000 +0000"> (NoMethodError)
Did you mean?  approved_by_id
irb(main):003> Projects::ArchiveAction.reflections["approved_by"]
=> nil
```

## When `Actions::RequiresApproval` is included
```
irb(main):001> Projects::ArchiveAction.first
  Projects::ArchiveAction Load (0.6ms)  SELECT "projects_archive_actions".* FROM "projects_archive_actions" ORDER BY "projects_archive_actions"."id" ASC LIMIT $1  [["LIMIT", 1]]
=> 
#<Projects::ArchiveAction:0x00007fd04502e438
 id: 1,
 team_id: 1,
 target_all: true,
 target_ids: ["1", "2"],
 failed_ids: [],
 last_completed_id: 2,
 started_at: Fri, 29 Sep 2023 05:13:38.089497000 UTC +00:00,
 completed_at: Fri, 29 Sep 2023 05:13:38.138579000 UTC +00:00,
 target_count: 2,
 performed_count: 2,
 scheduled_for: nil,
 sidekiq_jid: "a93846593245595f801362af",
 created_by_id: 1,
 approved_by_id: nil,
 created_at: Fri, 29 Sep 2023 05:13:37.902600000 UTC +00:00,
 updated_at: Fri, 29 Sep 2023 05:13:38.142854000 UTC +00:00>
irb(main):002> Projects::ArchiveAction.first.approved_by
  Projects::ArchiveAction Load (1.3ms)  SELECT "projects_archive_actions".* FROM "projects_archive_actions" ORDER BY "projects_archive_actions"."id" ASC LIMIT $1  [["LIMIT", 1]]
=> nil
irb(main):003> Projects::ArchiveAction.reflections["approved_by"]
=> 
#<ActiveRecord::Reflection::BelongsToReflection:0x00007fd050f8e120
 @active_record=
  Projects::ArchiveAction(id: integer, team_id: integer, target_all: boolean, target_ids: jsonb, failed_ids: jsonb, last_completed_id: integer, started_at: datetime, completed_at: datetime, target_count: integer, performed_count: integer, scheduled_for: datetime, sidekiq_jid: string, created_by_id: integer, approved_by_id: integer, created_at: datetime, updated_at: datetime),
 @class_name="Membership",
 @foreign_key="approved_by_id",
 @inverse_name=nil,
 @klass=
  Membership(id: integer, user_id: integer, team_id: integer, created_at: datetime, updated_at: datetime, invitation_id: integer, user_first_name: string, user_last_name: string, user_profile_photo_id: string, user_email: string, added_by_id: integer, platform_agent_of_id: integer, role_ids: jsonb, platform_agent: boolean),
 @name=:approved_by,
 @options={:class_name=>"Membership", :optional=>true},
 @plural_name="approved_bys",
 @scope=nil>

```

## Where we declare the reflections
You can see `approved_by` being declared in `Actions::RequiresApproval` here:

https://github.com/bullet-train-pro/bullet_train-action_models/blob/ff7f91e988085778430cd548ca25f6beab8a4925/app/models/concerns/actions/requires_approval.rb#L5

On the other hand, our other actions include the `Actions::TracksCreator` module by default which is why the `created_by` attribute wasn't giving us any issues.

https://github.com/bullet-train-pro/bullet_train-action_models/blob/ff7f91e988085778430cd548ca25f6beab8a4925/app/models/concerns/actions/tracks_creator.rb#L5

## Other Changes
I also changed `created_by_id` in the strong params for uniformity.
