### PR TITLE
Fix action transformation on targets one scaffolding.

### DIFF
--- a/lib/scaffolding/action_model_targets_one_transformer.rb
+++ b/lib/scaffolding/action_model_targets_one_transformer.rb
@@ -95,22 +95,25 @@ class Scaffolding::ActionModelTargetsOneTransformer < Scaffolding::ActionModelTr
   end
 
   def replacement_for(string)
+    # I'm not sure at what point we broke this, but `action` started including the namespace and that broke this method.
+    action_without_namespace = action.split("::").last
+
     case string
     # Some weird edge cases we unwittingly introduced in the emoji example.
     when "Targets One to"
       # e.g. "Archive"
       # If someone wants language like "Targets One to", they have to add it manually or name their model that.
-      action.titlecase
+      action_without_namespace.titlecase
     when "append an emoji to"
       # e.g. "archive"
       # If someone wants language like "append an emoji to", they have to add it manually.
-      action.humanize
+      action_without_namespace.humanize
     when "TargetsOne"
-      action
+      action_without_namespace
     when "targets_one"
-      action.underscore
+      action_without_namespace.underscore
     when "Targets One"
-      action.titlecase
+      action_without_namespace.titlecase
     else
       "🛑"
     end


### PR DESCRIPTION
The following was broken on a fresh copy of the starter repo with this package installed:

```
bin/super-scaffold crud Newsletter Team name:text_field
bin/super-scaffold action-model:targets-one Newsletters::CreateIssue Newsletter Team
```