### PR TITLE
[CI] Fix branch matching problem

### DIFF
--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -7,7 +7,7 @@ STARTER_REPO_BRANCH="main"
 CI_BRANCH=$CIRCLE_BRANCH
 if [[ -v CI_BRANCH ]]
 then
-  BRANCH_RESPONSE=$(curl --verbose -H "Accept: application.vnd.github+json" https://api.github.com/repos/bullet-train-co/bullet_train/branches/$CI_BRANCH)
+  BRANCH_RESPONSE=$(curl --verbose https://api.github.com/repos/bullet-train-co/bullet_train/branches/$CI_BRANCH)
 
   echo "Branch response ===================="
   echo $BRANCH_RESPONSE


### PR DESCRIPTION
For some reason all of a sudden GitHub doesn't like us sending a header.

This prevents us from being able to find a matching branch in the starter repo.

It also causes the "checkout and link starter repo" step to take a _really_ long time to run for some reason.