### PR TITLE
Raise error for redundant namespaces

### DIFF
--- a/lib/bullet_train/action_models/scaffolders/performs_export_scaffolder.rb
+++ b/lib/bullet_train/action_models/scaffolders/performs_export_scaffolder.rb
@@ -37,6 +37,7 @@ module BulletTrain
           parent_models = parent_models.map(&:classify).uniq
 
           transformer = Scaffolding::ActionModelPerformsExportTransformer.new(action_model, target_model, parent_models)
+          transformer.check_namespace
 
           `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::PerformsExportAction")} #{transformer.transform_string("absolutely_abstract_creative_concept")}:references target_all:boolean target_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} failed_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} last_completed_id:integer started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references approved_by:references fields:#{Scaffolding.mysql? ? "json" : "jsonb"}`
 

--- a/lib/bullet_train/action_models/scaffolders/performs_import_scaffolder.rb
+++ b/lib/bullet_train/action_models/scaffolders/performs_import_scaffolder.rb
@@ -37,6 +37,7 @@ module BulletTrain
           parent_models = parent_models.map(&:classify).uniq
 
           transformer = Scaffolding::ActionModelPerformsImportTransformer.new(action_model, target_model, parent_models)
+          transformer.check_namespace
 
           `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::PerformsImportAction")} #{transformer.transform_string("absolutely_abstract_creative_concept")}:references target_all:boolean target_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references approved_by:references mapping:#{Scaffolding.mysql? ? "json" : "jsonb"} copy_mapping_from:references succeeded_count:integer failed_count:integer last_processed_row:integer`
 

--- a/lib/bullet_train/action_models/scaffolders/targets_many_scaffolder.rb
+++ b/lib/bullet_train/action_models/scaffolders/targets_many_scaffolder.rb
@@ -29,6 +29,7 @@ module BulletTrain
           parent_models = parent_models.map(&:classify).uniq
 
           transformer = Scaffolding::ActionModelTargetsManyTransformer.new(action_model, target_model, parent_models)
+          transformer.check_namespace
 
           `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::TargetsManyAction")} #{transformer.transform_string("absolutely_abstract_creative_concept")}:references target_all:boolean target_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} failed_ids:#{Scaffolding.mysql? ? "json" : "jsonb"} last_completed_id:integer started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references approved_by:references`
 

--- a/lib/bullet_train/action_models/scaffolders/targets_one_parent_scaffolder.rb
+++ b/lib/bullet_train/action_models/scaffolders/targets_one_parent_scaffolder.rb
@@ -29,6 +29,7 @@ module BulletTrain
           parent_models = parent_models.map(&:classify).uniq
 
           transformer = Scaffolding::ActionModelTargetsOneParentTransformer.new(action_model, target_model, parent_models)
+          transformer.check_namespace
 
           puts `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::TargetsOneParentAction")} #{transformer.transform_string("absolutely_abstract_creative_concept")}:references started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references approved_by:references`
 

--- a/lib/bullet_train/action_models/scaffolders/targets_one_scaffolder.rb
+++ b/lib/bullet_train/action_models/scaffolders/targets_one_scaffolder.rb
@@ -38,6 +38,7 @@ module BulletTrain
           parent_models = parent_models.map(&:classify).uniq
 
           transformer = Scaffolding::ActionModelTargetsOneTransformer.new(action_model, target_model, parent_models)
+          transformer.check_namespace
 
           `yes n | bin/rails g model #{transformer.transform_string("Scaffolding::CompletelyConcrete::TangibleThings::TargetsOneAction")} #{transformer.transform_string("tangible_thing")}:references started_at:datetime completed_at:datetime target_count:integer performed_count:integer scheduled_for:datetime sidekiq_jid:string created_by:references approved_by:references`
 

--- a/lib/scaffolding/action_model_transformer.rb
+++ b/lib/scaffolding/action_model_transformer.rb
@@ -33,7 +33,7 @@ class Scaffolding::ActionModelTransformer < Scaffolding::Transformer
     child_parts = child.split("::")
     if action_parts.shift.singularize == child_parts.shift
       puts "When creating an Action Model, you don't have to namespace the action to the model you want to perform the action on.".red
-      puts "i.e. - bin/super-scaffold action-model:#{targets_n.gsub(/_/, "-")} #{action_parts.join("::")} #{child} #{parent}"
+      puts "i.e. - bin/super-scaffold action-model:#{targets_n.tr("_", "-")} #{action_parts.join("::")} #{child} #{parent}"
       exit
     end
   end

--- a/lib/scaffolding/action_model_transformer.rb
+++ b/lib/scaffolding/action_model_transformer.rb
@@ -28,6 +28,16 @@ class Scaffolding::ActionModelTransformer < Scaffolding::Transformer
     action_model_class.match?(/Admin::/)
   end
 
+  def check_namespace
+    action_parts = action.split("::")
+    child_parts = child.split("::")
+    if action_parts.shift.singularize == child_parts.shift
+      puts "When creating an Action Model, you don't have to namespace the action to the model you want to perform the action on.".red
+      puts "i.e. - bin/super-scaffold action-model:#{targets_n.gsub(/_/, "-")} #{action_parts.join("::")} #{child} #{parent}"
+      exit
+    end
+  end
+
   def add_ability_line_to_roles_yml
     role_file = "./config/models/roles.yml"
 


### PR DESCRIPTION
Closes #89.

I assume that we want to do this for all types of Action Models, but if there's anything extra I should do here I'd be glad to look into it.