### PR TITLE
Allow action models to specify which Sidekiq queue they should run on.

### DIFF
--- a/app/models/concerns/actions/processes_async.rb
+++ b/app/models/concerns/actions/processes_async.rb
@@ -14,8 +14,11 @@ module Actions::ProcessesAsync
     Actions::BackgroundActionHealthCheckWorker.perform_at(health_check_frequency.from_now, self.class.name, id)
   end
 
+  def sidekiq_queue
+  end
+
   def dispatch
-    self.sidekiq_jid = Actions::BackgroundActionWorker.perform_async(self.class.name, id)
+    self.sidekiq_jid = Actions::BackgroundActionWorker.set(sidekiq_queue ? {queue: sidekiq_queue} : {}).perform_async(self.class.name, id)
     save
   end
 end


### PR DESCRIPTION
Action Model can define which Sidekiq queue they should run on like so:

```
def sidekiq_queue
  "imports"
end
```
