### PR TITLE
Build path for action models dynamically when namespace has a resource

### DIFF
--- a/app/controllers/account/scaffolding/completely_concrete/tangible_things/targets_one_parent_actions_controller.rb
+++ b/app/controllers/account/scaffolding/completely_concrete/tangible_things/targets_one_parent_actions_controller.rb
@@ -26,7 +26,7 @@ class Account::Scaffolding::CompletelyConcrete::TangibleThings::TargetsOneParent
     respond_to do |format|
       if @targets_one_parent_action.approve_by(current_membership)
         format.html { redirect_to [:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things], notice: I18n.t("scaffolding/completely_concrete/tangible_things/targets_one_parent_actions.notifications.approved") }
-        format.json { render :show, status: :ok, location: [:account, @targets_one_parent_action] }
+        format.json { render :show, status: :ok, location: helpers.build_action_model_path(@targets_one_parent_action) }
       else
         format.html { render :show, status: :unprocessable_entity }
         format.json { render json: @targets_one_parent_action.errors, status: :unprocessable_entity }
@@ -44,7 +44,7 @@ class Account::Scaffolding::CompletelyConcrete::TangibleThings::TargetsOneParent
 
       if @targets_one_parent_action.save
         format.html { redirect_to [:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things_targets_one_parent_actions], notice: I18n.t("scaffolding/completely_concrete/tangible_things/targets_one_parent_actions.notifications.created") }
-        format.json { render :show, status: :created, location: [:account, @targets_one_parent_action] }
+        format.json { render :show, status: :created, location: helpers.build_action_model_path(@targets_one_parent_action) }
       else
         format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @targets_one_parent_action.errors, status: :unprocessable_entity }
@@ -57,8 +57,8 @@ class Account::Scaffolding::CompletelyConcrete::TangibleThings::TargetsOneParent
   def update
     respond_to do |format|
       if @targets_one_parent_action.update(targets_one_parent_action_params)
-        format.html { redirect_to [:account, @targets_one_parent_action], notice: I18n.t("scaffolding/completely_concrete/tangible_things/targets_one_parent_actions.notifications.updated") }
-        format.json { render :show, status: :ok, location: [:account, @targets_one_parent_action] }
+        format.html { redirect_to helpers.build_action_model_path(@targets_one_parent_action), notice: I18n.t("scaffolding/completely_concrete/tangible_things/targets_one_parent_actions.notifications.updated") }
+        format.json { render :show, status: :ok, location: helpers.build_action_model_path(@targets_one_parent_action) }
       else
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @targets_one_parent_action.errors, status: :unprocessable_entity }

--- a/app/helpers/account/action_model_helper.rb
+++ b/app/helpers/account/action_model_helper.rb
@@ -1,3 +1,5 @@
+require "masamune"
+
 module Account::ActionModelHelper
   def export_field_options(export_action)
     export_action.class::AVAILABLE_FIELDS.keys.map do |key|
@@ -13,5 +15,73 @@ module Account::ActionModelHelper
 
   def import_label_with_time(import_action)
     "#{import_action.label_string} - Imported #{time_ago_in_words(import_action.created_at)} ago"
+  end
+
+  def build_action_model_path(request, action, type: nil)
+    url_for([:account, action])
+  rescue NoMethodError
+    routes_file = File.read("config/routes.rb")
+    msmn = Masamune::AbstractSyntaxTree.new(routes_file)
+    resources = msmn.method_calls(token_value: "resources")
+    namespaces = msmn.method_calls(token_value: "namespace")
+    routes_keys = (resources + namespaces).map do |route|
+      route.arguments.slice.split(",").first.gsub(/^:/, "")
+    end
+
+    action_model_parts = action.class.name.split("::")
+    path_parts = request.path_info.split("/").reject(&:empty?)
+
+    action_model_path = path_parts.map do |part|
+      camelized_part = part.capitalize.camelize
+
+      if !routes_keys.include?(part)
+        # Skip when the part is an ID
+      elsif !action_model_parts.include?(camelized_part)
+        # If it's a part of the path but not an ID or in
+        # the Action Model namespace, just return it as is.
+        # i.e. - :account
+        part.to_sym
+      else
+        idx = path_parts.index(part)
+
+        # If the next part in the path is an ID, return the object.
+        # This is a likely a resource. Return the object.
+        # TODO: compensate for `nil` at end of path.
+        if !routes_keys.include?(path_parts[idx + 1])
+          klass = camelized_part.singularize.safe_constantize
+          klass.nil? ? part.to_sym : klass.find(path_parts[idx + 1])
+        else
+          # This is a namespace. Return as is.
+          part.to_sym
+        end
+      end
+    end.compact
+
+    object_arguments = action_model_path.reject { |part| part.is_a?(Symbol) } << action
+    new_path_parts = action_model_path.map do |part|
+      part.is_a?(Symbol) ? part.to_s : part.class.name.underscore
+    end
+
+    # Add each part of the action to the end if it's not already there.
+    action_model_parts.each do |part|
+      underscored_argument_classes = object_arguments.map { |arg| arg.class.name.underscore }
+      unless new_path_parts.include?(part.underscore.singularize) || new_path_parts.include?(part.underscore.pluralize)
+        new_path_parts << if underscored_argument_classes.include?(part.underscore)
+          part.underscore.singularize
+        else
+          part.underscore
+        end
+      end
+    end
+
+    # Ensure the path is singular for non-collection actions.
+    if object_arguments.last == action
+      new_path_parts[-1] = new_path_parts.last.singularize
+    end
+
+    # Finally, return the path method.
+    # i.e. - account_action_name_path(targeted_object, action)
+    path_method = "#{"edit_" if type == :edit}#{new_path_parts.join("_")}_path".to_sym
+    send(path_method, *object_arguments)
   end
 end

--- a/app/helpers/account/action_model_helper.rb
+++ b/app/helpers/account/action_model_helper.rb
@@ -17,71 +17,33 @@ module Account::ActionModelHelper
     "#{import_action.label_string} - Imported #{time_ago_in_words(import_action.created_at)} ago"
   end
 
-  def build_action_model_path(request, action, type: nil)
+  # We can get the URL for most actions by passing [:account, action],
+  # but we need a little more manpower to take care of deeply nested actions.
+  # This helper ensures we get the right objects and path name for the action we're using.
+  def build_action_model_path(action, type: nil)
     url_for([:account, action])
   rescue NoMethodError
-    routes_file = File.read("config/routes.rb")
-    msmn = Masamune::AbstractSyntaxTree.new(routes_file)
-    resources = msmn.method_calls(token_value: "resources")
-    namespaces = msmn.method_calls(token_value: "namespace")
-    routes_keys = (resources + namespaces).map do |route|
-      route.arguments.slice.split(",").first.gsub(/^:/, "")
-    end
+    class_names = action.class.name.split("::")
+    object_arguments = []
 
-    action_model_parts = action.class.name.split("::")
-    path_parts = request.path_info.split("/").reject(&:empty?)
-
-    action_model_path = path_parts.map do |part|
-      camelized_part = part.capitalize.camelize
-
-      if !routes_keys.include?(part)
-        # Skip when the part is an ID
-      elsif !action_model_parts.include?(camelized_part)
-        # If it's a part of the path but not an ID or in
-        # the Action Model namespace, just return it as is.
-        # i.e. - :account
-        part.to_sym
+    # Check each namespace part and get the object if necessary.
+    path_parts = class_names.map do |class_name|
+      if action.respond_to?("#{class_name.underscore.singularize}_id".to_sym)
+        klass = class_name.singularize.constantize
+        attribute_id = action.send("#{class_name.underscore.singularize}_id".to_sym)
+        object_arguments << klass.find(attribute_id)
+        class_name.underscore.singularize
       else
-        idx = path_parts.index(part)
-
-        # If the next part in the path is an ID, return the object.
-        # This is a likely a resource. Return the object.
-        # TODO: compensate for `nil` at end of path.
-        if !routes_keys.include?(path_parts[idx + 1])
-          klass = camelized_part.singularize.safe_constantize
-          klass.nil? ? part.to_sym : klass.find(path_parts[idx + 1])
-        else
-          # This is a namespace. Return as is.
-          part.to_sym
-        end
-      end
-    end.compact
-
-    object_arguments = action_model_path.reject { |part| part.is_a?(Symbol) } << action
-    new_path_parts = action_model_path.map do |part|
-      part.is_a?(Symbol) ? part.to_s : part.class.name.underscore
-    end
-
-    # Add each part of the action to the end if it's not already there.
-    action_model_parts.each do |part|
-      underscored_argument_classes = object_arguments.map { |arg| arg.class.name.underscore }
-      unless new_path_parts.include?(part.underscore.singularize) || new_path_parts.include?(part.underscore.pluralize)
-        new_path_parts << if underscored_argument_classes.include?(part.underscore)
-          part.underscore.singularize
-        else
-          part.underscore
-        end
+        class_name.underscore
       end
     end
+    path_parts.unshift(:account)
 
-    # Ensure the path is singular for non-collection actions.
-    if object_arguments.last == action
-      new_path_parts[-1] = new_path_parts.last.singularize
-    end
+    # TODO: We might not need this like (or type: :collection altogether), just keeping it here for reference.
+    (type == :collection) ? path_parts[-1] = path_parts[-1].pluralize : object_arguments << action
 
-    # Finally, return the path method.
-    # i.e. - account_action_name_path(targeted_object, action)
-    path_method = "#{"edit_" if type == :edit}#{new_path_parts.join("_")}_path".to_sym
+    # Build the path
+    path_method = "#{"edit_" if type == :edit}#{path_parts.join("_")}_path"
     send(path_method, *object_arguments)
   end
 end

--- a/app/helpers/account/action_model_helper.rb
+++ b/app/helpers/account/action_model_helper.rb
@@ -1,5 +1,3 @@
-require "masamune"
-
 module Account::ActionModelHelper
   def export_field_options(export_action)
     export_action.class::AVAILABLE_FIELDS.keys.map do |key|

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/targets_one_parent_actions/_breadcrumbs.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/targets_one_parent_actions/_breadcrumbs.html.erb
@@ -3,6 +3,6 @@
 <%= render 'account/scaffolding/completely_concrete/tangible_things/breadcrumbs', creative_concept: absolutely_abstract_creative_concept %>
 <%= render 'account/shared/breadcrumb', label: t('.label'), url: [:account, absolutely_abstract_creative_concept, :completely_concrete_tangible_things_targets_one_parent_actions] %>
 <% if targets_one_parent_action&.persisted? %>
-  <%= render 'account/shared/breadcrumb', label: targets_one_parent_action.label_string, url: [:account, targets_one_parent_action] %>
+  <%= render 'account/shared/breadcrumb', label: targets_one_parent_action.label_string, url: build_action_model_path(targets_one_parent_action) %>
 <% end %>
 <%= render 'account/shared/breadcrumbs/actions', only_for: 'scaffolding/completely_concrete/tangible_things/targets_one_parent_actions' %>

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/targets_one_parent_actions/_form.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/targets_one_parent_actions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: targets_one_parent_action, url: (targets_one_parent_action.persisted? ? [:account, targets_one_parent_action] : [:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things_targets_one_parent_actions]), local: true, class: 'form' do |form| %>
+<%= form_with model: targets_one_parent_action, url: (targets_one_parent_action.persisted? ? build_action_model_path(targets_one_parent_action) : [:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things_targets_one_parent_actions]), local: true, class: 'form' do |form| %>
   <%= render 'account/shared/forms/errors', form: form %>
   <%= form.hidden_field :allow_empty_form, value: nil %>
 
@@ -11,7 +11,7 @@
   <div class="buttons">
     <%= form.submit (form.object.persisted? ? t('.buttons.update') : t('.buttons.create')), class: "button" %>
     <% if form.object.persisted? %>
-    <%= link_to t('global.buttons.cancel'), [:account, targets_one_parent_action], class: "button-secondary" %>
+    <%= link_to t('global.buttons.cancel'), build_action_model_path(targets_one_parent_action), class: "button-secondary" %>
     <% else %>
     <%= link_to t('global.buttons.cancel'), [:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things_targets_one_parent_actions], class: "button-secondary" %>
     <% end %>

--- a/app/views/account/scaffolding/completely_concrete/tangible_things/targets_one_parent_actions/show.html.erb
+++ b/app/views/account/scaffolding/completely_concrete/tangible_things/targets_one_parent_actions/show.html.erb
@@ -23,8 +23,8 @@
         <% end %>
 
         <% p.content_for :actions do %>
-          <%= link_to t('.buttons.edit'), [:edit, :account, @targets_one_parent_action], class: first_button_primary if can? :edit, @targets_one_parent_action %>
-          <%= button_to t('.buttons.destroy'), [:account, @targets_one_parent_action], method: :delete, class: first_button_primary, data: { confirm: t('.buttons.confirmations.destroy', model_locales(@targets_one_parent_action)) } if can? :destroy, @targets_one_parent_action %>
+          <%= link_to t('.buttons.edit'), build_action_model_path(@targets_one_parent_action, type: :edit), class: first_button_primary if can? :edit, @targets_one_parent_action %>
+          <%= button_to t('.buttons.destroy'), build_action_model_path(@targets_one_parent_action), method: :delete, class: first_button_primary, data: { confirm: t('.buttons.confirmations.destroy', model_locales(@targets_one_parent_action)) } if can? :destroy, @targets_one_parent_action %>
           <%= link_to t('global.buttons.back'), [:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things_targets_one_parent_actions], class: first_button_primary %>
         <% end %>
       <% end %>

--- a/lib/scaffolding/action_model_transformer.rb
+++ b/lib/scaffolding/action_model_transformer.rb
@@ -287,7 +287,7 @@ class Scaffolding::ActionModelTransformer < Scaffolding::Transformer
       routing_details.each do |details|
         routes_manipulator = Scaffolding::RoutesFileManipulator.new(details[:file_name], child, parent)
         routes_manipulator.apply([details[:namespace]])
-        add_line_to_action_resource("  member do\npost 'approve'\nend", routes_manipulator)
+        add_line_to_action_resource("member do\n  post 'approve'\nend", routes_manipulator)
         Scaffolding::FileManipulator.write(details[:file_name], routes_manipulator.lines)
       end
     rescue BulletTrain::SuperScaffolding::CannotFindParentResourceException => exception


### PR DESCRIPTION
Closes #93. This PR also assumes the routes setup spelled out in [this comment](https://github.com/bullet-train-pro/bullet_train-action_models/issues/93#issuecomment-1782677525).

# The Problem
Actions can be namespaced like this: `Listings::PublishAction`.
However, when the routes are deeply nested and parents in the hierarchy are resources, we don't get the proper routes.

In the model setup in #93, we have the following:
```
Newsletters::Issues::SendAction
```

Super scaffolding generates links to urls with arrays like this:
```ruby
# Passed to `link_to`, etc., and generates a path for us
[:account, send_action]
```

This would produce a path like this, because the `send_action` class is `Newsletters::Issues::SendAction`:
```ruby
account_newsletters_issues_send_action_path(send_action)
```

This wasn't working because newsletters is a resource, and `[:account, send_action]` has no knowledge of the newsletter resource, raising a `NoMethodError`. What we _really_ need is this:

```ruby
account_newsletter_issues_send_action_path(newsletter, send_action)
```

It should be noted that in some places, the parent resource was being scaffolded correctly for collection actions. For example, in #93 I brought up this code:
```ruby
<%= button_to "Send", [:new, :account, newsletter, :issues_send_action], method: :get, class: 'button-secondary', form: {class: 'button_to'} %>
```

The link here works for collection actions, but when we need both the `newsletter` resource and the `send_action` resources, we weren't scaffolding the proper routes, and it just showed up in different places like `[:account, send_action]`.

# The Solution
What this PR does is, it takes the current url path and builds the action model path based off of that. So it does the following:
1. Takes the current url
2. Reads each part of the url and determines if it's a resource or just a namespace
3. Registers the object of each resource in the path to eventually pass as arguments
4. Builds the `path_method`, then passes the arguments we got in step 3

So ultimately we're calling this: `send(path_method, *object_arguments)`
Which in our example results in this:
```ruby
account_newsletter_issues_send_action_path(newsletter, send_action)
```

The reason for using the requests url is that I'm assuming we only want these links when we're on a page in the namespace. For example, we wouldn't call the action from another random resource in the application.

# Implementation
In our views like [_action.html.erb](https://github.com/bullet-train-co/bullet_train-core/blob/d487d89d1cbe6abef4a102e8e911b0e6d5c4eb72/bullet_train-themes-light/app/views/themes/light/actions/_action.html.erb#L23) in `bullet_train-themes-light`, we would do the following:
```erb
<% action_model_path = build_action_model_path(request, action) %>
<%= link_to t("#{action.class.name.pluralize.underscore}.buttons.shorthand.show"), action_model_path, class: 'button-secondary button-smaller' %>
```

I will have to make joint PR which should include the following:
1. Replacement of url arrays with backwards compatibility
2. Updates to Super Scaffolding to scaffold this helper instead of arrays like [:account, send_action]
3. Potentially add documentation. I don't think this will affect developers with actions they currently have in place because we're first checking with this:
```ruby
def build_action_model_path(request, action, type: nil)
  url_for([:account, action])
rescue NoMethodError
  ...
end
```

If we need documentation to explain what's going on though, I can write that.