### PR TITLE
Fix string transformation for Performs Import action

### DIFF
--- a/app/controllers/account/scaffolding/completely_concrete/tangible_things/performs_import_actions_controller.rb
+++ b/app/controllers/account/scaffolding/completely_concrete/tangible_things/performs_import_actions_controller.rb
@@ -57,7 +57,7 @@ class Account::Scaffolding::CompletelyConcrete::TangibleThings::PerformsImportAc
   # PATCH/PUT /account/scaffolding/completely_concrete/tangible_things/performs_import_actions/:id
   # PATCH/PUT /account/scaffolding/completely_concrete/tangible_things/performs_import_actions/:id.json
   def update
-    populate_mappings(params["scaffolding_completely_concrete_tangible_things_csv_import_action"])
+    populate_mappings(params["scaffolding_completely_concrete_tangible_things_performs_import_action"])
 
     respond_to do |format|
       if @performs_import_action.update(performs_import_action_params)
@@ -105,7 +105,7 @@ class Account::Scaffolding::CompletelyConcrete::TangibleThings::PerformsImportAc
   def populate_mappings(mappings)
     mappings.each do |mapping|
       attribute = mapping.first.gsub(/^mapping_/, "")
-      @csv_import_action.mapping[attribute] = mapping.last.empty? ? nil : mapping.last
+      @performs_import_action.mapping[attribute] = mapping.last.empty? ? nil : mapping.last
     end
   end
 end

--- a/app/controllers/concerns/actions/controller_support.rb
+++ b/app/controllers/concerns/actions/controller_support.rb
@@ -3,7 +3,7 @@ module Actions::ControllerSupport
 
   def assign_mapping(strong_params, subject, attribute)
     strong_params[attribute] = subject.send(attribute).keys.map do |key|
-      [key, params[subject.class.name.underscore.gsub("/", "_")]["mapping_#{key.underscore}"]]
+      [key, params[subject.class.name.underscore.tr("/", "_")]["mapping_#{key.underscore}"]]
     end.to_h
   end
 end

--- a/app/controllers/concerns/actions/controller_support.rb
+++ b/app/controllers/concerns/actions/controller_support.rb
@@ -3,7 +3,7 @@ module Actions::ControllerSupport
 
   def assign_mapping(strong_params, subject, attribute)
     strong_params[attribute] = subject.send(attribute).keys.map do |key|
-      [key, params[subject.class.name.underscore.tr("/", "_")]["mapping_#{key.underscore}"]]
+      [key, params[subject.class.name.underscore.gsub("/", "_")]["mapping_#{key.underscore}"]]
     end.to_h
   end
 end


### PR DESCRIPTION
We were using incorrect strings to transform content in newly scaffolded controllers for the Performs Import action, so I fixed that here.

Also, after some experimentation, I figured out that we can only use CSVs with underscored strings as column names. For example:
```
project_id,title
1,foo
2,bar
3,baz
```

When loading a CSV, we don't have a check of some sort to ensure the column names conform to this standard. Should we change the strings when loading, or should we handle this another way?

## Tests
Tests are currently failing due to https://github.com/bullet-train-co/bullet_train/issues/1153.

The actual Action Model tests we have in place were passing because we scaffold a CsvImport model which matched the improperly transformed strings.