### PR TITLE
Find API version dynamically when scaffolding action routes

### DIFF
--- a/lib/scaffolding/action_model_transformer.rb
+++ b/lib/scaffolding/action_model_transformer.rb
@@ -274,8 +274,8 @@ class Scaffolding::ActionModelTransformer < Scaffolding::Transformer
           namespace: "account"
         },
         {
-          file_name: "config/routes/api/v1.rb",
-          namespace: "v1"
+          file_name: "config/routes/api/#{BulletTrain::Api.current_version}.rb",
+          namespace: BulletTrain::Api.current_version
         }
       ]
 


### PR DESCRIPTION
Fixes #99.

To test, I scaffolded the `Project` model as per [the documentation](https://bullettrain.co/docs/action-models#basic-example):

```
rails generate super_scaffold Project Team name:text_field
rails generate super_scaffold:action_models:targets_many Archive Project Team
```

Here is the `git status` with this branch where you can see that the correct routes file is being updated.


![Screenshot from 2024-03-05 15-56-39](https://github.com/bullet-train-pro/bullet_train-action_models/assets/10546292/458e71f2-d25a-4f1f-8796-22c27ca3111c)

We shouldn't need anything else besides the changes I have here, but it might help us to incorporate a test for the bump version task.