### PR TITLE
Fix Action Models select multiple no longer working

### DIFF
--- a/app/views/shared/tables/_checkbox.html.erb
+++ b/app/views/shared/tables/_checkbox.html.erb
@@ -1,7 +1,7 @@
 <td class="bulk-actions-checkbox-cell">
   <label>
     <%= render 'shared/fields/option', method: :bulk_actions_ids, single_check_box: true, append_class: '-mt-0.5',
-      option_field_options: {
+      options: {
         value: object.id,
         checked: false,
         data: { 'bulk-actions-target': 'checkbox', 'action': 'bulk-actions#updateSelectedIds' }

--- a/app/views/shared/tables/_select_all.html.erb
+++ b/app/views/shared/tables/_select_all.html.erb
@@ -1,7 +1,7 @@
 <th class="bulk-actions-checkbox-cell">
   <label style="line-height: 0;">
     <%= render 'shared/fields/option', method: :bulk_actions_select_all, single_check_box: true, append_class: '-mt-1',
-      option_field_options: {
+      options: {
         value: 'select_all',
         checked: false,
         data: { 'bulk-actions-target': 'selectAllCheckbox', 'action': 'bulk-actions#selectAllOrNone' }


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train-core/issues/807

When switching to use the `option` partial in #51, using `option_field_options` for feeding data and other attributes to the option field broke the select all and bulk actions buttons.

This PR uses the `options` field we standardized in https://github.com/bullet-train-co/bullet_train-core/pull/633