### PR TITLE
Update and rename 20220715105001 export actions

### DIFF
--- a/db/migrate/20220715105001_create_scaffolding_completely_concrete_tangible_things_performs_export_actions.rb
+++ b/db/migrate/20220715105001_create_scaffolding_completely_concrete_tangible_things_performs_export_actions.rb
@@ -1,13 +1,13 @@
 class CreateScaffoldingCompletelyConcreteTangibleThingsPerformsExportActions < ActiveRecord::Migration[7.0]
   def change
     create_table :sc_completely_concrete_tangible_things_performs_export_actions do |t|
-      t.references :absolutely_abstract_creative_concept, null: false, foreign_key: {to_table: "scaffolding_absolutely_abstract_creative_concepts"}, index: {name: "index_tangible_things_export_on_creative_concept_id"}
+      t.references :absolutely_abstract_creative_concept, null: false, foreign_key: {to_table: "scaffolding_absolutely_abstract_creative_concepts"}, index: {name: "index_performs_export_actions_on_abstract_creative_concept_id"}
       t.boolean :target_all, default: false
       t.jsonb :target_ids, default: []
       t.bigint :target_count
       t.bigint :performed_count, default: 0
-      t.references :created_by, null: true, foreign_key: {to_table: "memberships"}, index: {name: "index_append_emoji_actions_on_created_by_id"}
-      t.references :approved_by, null: true, foreign_key: {to_table: "memberships"}, index: {name: "index_append_emoji_actions_on_approved_by_id"}
+      t.references :created_by, null: true, foreign_key: {to_table: "memberships"}, index: {name: "index_performs_exports_on_created_by_id"}
+      t.references :approved_by, null: true, foreign_key: {to_table: "memberships"}, index: {name: "index_performs_exports_on_approved_by_id"}
       t.datetime :scheduled_for
       t.datetime :started_at
       t.datetime :completed_at
@@ -17,3 +17,5 @@ class CreateScaffoldingCompletelyConcreteTangibleThingsPerformsExportActions < A
     end
   end
 end
+
+


### PR DESCRIPTION
- Rename the migrate file to match what it creates on DB
- Update index names to match what they represent and ensure rake db:migrate works.