### PR TITLE
Update Actions::ProcessesAsync to allow overriding

### DIFF
--- a/app/models/concerns/actions/processes_async.rb
+++ b/app/models/concerns/actions/processes_async.rb
@@ -18,7 +18,15 @@ module Actions::ProcessesAsync
   end
 
   def dispatch
-    self.sidekiq_jid = Actions::BackgroundActionWorker.set(sidekiq_queue ? {queue: sidekiq_queue} : {}).perform_async(self.class.name, id)
+    self.sidekiq_jid = worker_class.set(job_options).perform_async(self.class.name, id)
     save
+  end
+
+  def job_options
+    sidekiq_queue ? {queue: sidekiq_queue} : {}
+  end
+
+  def worker_class
+    Actions::BackgroundActionWorker
   end
 end


### PR DESCRIPTION
Allow implementation to override the worker class and/or the job options passed to `set` without overriding the `dispatch` method.