### PR TITLE
Fix tests for newer versions of ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
       railties (>= 5.2)
       thread-local (>= 1.1.0)
     cancancan (3.5.0)
-    charlock_holmes (0.7.7)
+    charlock_holmes (0.7.9)
     chronic (0.10.2)
     cloudinary (1.28.0)
       aws_cf_signer
@@ -399,6 +399,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       bullet_train-super_scaffolding
       csv
       matrix
-      rails (>= 6.0.0, < 8)
+      rails (>= 6.0.0)
       roo
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,8 +5,9 @@ PATH
       bullet_train
       bullet_train-fields
       bullet_train-super_scaffolding
+      csv
       matrix
-      rails (>= 6.0.0)
+      rails (>= 6.0.0, < 8)
       roo
 
 GEM
@@ -165,6 +166,7 @@ GEM
     crass (1.0.6)
     css_parser (1.16.0)
       addressable
+    csv (3.3.4)
     date (3.3.3)
     devise (4.9.3)
       bcrypt (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     builder (3.2.4)
-    bullet_train (1.6.21)
+    bullet_train (1.6.25)
       awesome_print
       bullet_train-has_uuid
       bullet_train-roles
@@ -120,7 +120,7 @@ GEM
       unicode-emoji
       valid_email
       xxhash
-    bullet_train-fields (1.6.21)
+    bullet_train-fields (1.20.0)
       chronic
       cloudinary
       phonelib
@@ -138,8 +138,8 @@ GEM
     bullet_train-super_load_and_authorize_resource (1.6.21)
       cancancan
       rails (>= 6.0.0)
-    bullet_train-super_scaffolding (1.6.21)
-      colorizer
+    bullet_train-super_scaffolding (1.20.0)
+      colorize
       indefinite_article
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
@@ -157,6 +157,7 @@ GEM
     cloudinary (1.28.0)
       aws_cf_signer
       rest-client (>= 2.0.0)
+    colorize (1.1.0)
     colorizer (0.0.2)
     commonmarker (0.23.10)
     concurrent-ruby (1.2.0)

--- a/bullet_train-action_models.gemspec
+++ b/bullet_train-action_models.gemspec
@@ -21,9 +21,10 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "test/controllers/**/*", "test/models/scaffolding/**/*", "test/factories/scaffolding/**/*", "LICENSE", "Rakefile", "README.md", ".bt-link"]
   end
 
-  spec.add_dependency "rails", ">= 6.0.0"
+  spec.add_dependency "rails", ">= 6.0.0", "< 8"
   spec.add_dependency "matrix"
   spec.add_dependency "roo"
+  spec.add_dependency "csv"
   spec.add_dependency "bullet_train"
   spec.add_dependency "bullet_train-super_scaffolding"
   # TODO: This is here because the main `bullet_train` gem needs it, but doesn't declare the dependency

--- a/bullet_train-action_models.gemspec
+++ b/bullet_train-action_models.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "test/controllers/**/*", "test/models/scaffolding/**/*", "test/factories/scaffolding/**/*", "LICENSE", "Rakefile", "README.md", ".bt-link"]
   end
 
-  spec.add_dependency "rails", ">= 6.0.0", "< 8"
+  spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "matrix"
   spec.add_dependency "roo"
   spec.add_dependency "csv"


### PR DESCRIPTION
`csv` is no longer an included default gem, so we have to list it as a dependency.